### PR TITLE
Minor optimizations to `atomic<shared_ptr<T>>` polyfill

### DIFF
--- a/provides/include/polyfill_v1/memory.hpp
+++ b/provides/include/polyfill_v1/memory.hpp
@@ -16,6 +16,7 @@ template <class Value> class atomic<shared_ptr<Value>> {
 public:
   atomic() {}
   atomic(const T &ptr) : m_ptr(ptr) {}
+  atomic(T &&ptr) : m_ptr(std::move(ptr)) {}
   atomic(const atomic &) = delete;
 
   static constexpr bool is_always_lock_free = false;

--- a/provides/include/polyfill_v1/memory.hpp
+++ b/provides/include/polyfill_v1/memory.hpp
@@ -26,7 +26,7 @@ public:
 
   T load(memory_order mo) const { return atomic_load_explicit(&m_ptr, mo); }
 
-  operator T() const { return load(); }
+  operator T() const { return atomic_load(&m_ptr); }
 
   void store(const T &desired) { atomic_store(&m_ptr, desired); }
 

--- a/provides/include/polyfill_v1/memory.hpp
+++ b/provides/include/polyfill_v1/memory.hpp
@@ -36,7 +36,7 @@ public:
   }
 
   const T &operator=(const T &desired) {
-    store(desired);
+    atomic_store(&m_ptr, desired);
     return desired;
   }
 

--- a/provides/include/polyfill_v1/memory.hpp
+++ b/provides/include/polyfill_v1/memory.hpp
@@ -15,7 +15,7 @@ template <class Value> class atomic<shared_ptr<Value>> {
 
 public:
   atomic() {}
-  atomic(const T &ptr) : m_ptr(atomic_load(&ptr)) {}
+  atomic(const T &ptr) : m_ptr(ptr) {}
   atomic(const atomic &) = delete;
 
   static constexpr bool is_always_lock_free = false;

--- a/provides/include/polyfill_v1/memory.hpp
+++ b/provides/include/polyfill_v1/memory.hpp
@@ -34,9 +34,9 @@ public:
     atomic_store_explicit(&m_ptr, desired, mo);
   }
 
-  T operator=(const T &desired) {
+  const T &operator=(const T &desired) {
     store(desired);
-    return load();
+    return desired;
   }
 
   atomic &operator=(const atomic &) = delete;


### PR DESCRIPTION
...because only `atomic<shared_ptr<T>>`s are subject to concurrent modification
by other threads.